### PR TITLE
Fix error message

### DIFF
--- a/src/FiberLoop.php
+++ b/src/FiberLoop.php
@@ -136,7 +136,7 @@ final class FiberLoop implements LoopInterface
         }
 
         if (isset($this->fiber) && $fiber === $this->fiber) {
-            throw new \Error("Cannot call %s::%s() from a loop event handler callback", self::class, __METHOD__);
+            throw new \Error(\sprintf("Cannot call %s::%s() from a loop event handler callback", self::class, __METHOD__));
         }
 
         $promise->{$method}(


### PR DESCRIPTION
Hi @trowski, thanks for your excellent work;-D.

Added missing `sprintf` in "Cannot call %s::%s() from a loop event handler callback" error message