### PR TITLE
Rename Fiber::this to Fiber::getCurrent

### DIFF
--- a/src/FiberLoop.php
+++ b/src/FiberLoop.php
@@ -97,7 +97,7 @@ final class FiberLoop implements LoopInterface
      */
     public function await(PromiseInterface $promise): mixed
     {
-        $fiber = \Fiber::this();
+        $fiber = \Fiber::getCurrent();
         $method = $promise instanceof ExtendedPromiseInterface ? 'done' : 'then';
 
         $resolved = false;

--- a/stubs/Fiber.php
+++ b/stubs/Fiber.php
@@ -75,7 +75,7 @@ final class Fiber
     /**
      * @return self|null Returns the currently executing fiber instance or NULL if in {main}.
      */
-    public static function this(): ?self { }
+    public static function getCurrent(): ?self { }
 
     /**
      * Suspend execution of the fiber. The fiber may be resumed with {@see Fiber::resume()} or {@see Fiber::throw()}.


### PR DESCRIPTION
Hi @trowski, I'm testing again react-fiber with PHP 8.1.0 RC, and I noticed that the Fiber class methods were changed a bit.

I noticed that the static method `Fiber::this()` was changed to `Fiber::getCurrent()`.

Thanks for your great work;-D